### PR TITLE
Redis Publisher connection error in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.11.3 AS builder
-RUN apk add --no-cache curl=7.67.0-r1
+RUN apk add --no-cache curl=7.67.0-r3
 
 RUN set -o pipefail
 # Download Qemu for making it support builds across multi-arch

--- a/docker/development/edge/etc/data-uploader/radar_iot_config.yaml
+++ b/docker/development/edge/etc/data-uploader/radar_iot_config.yaml
@@ -1,0 +1,49 @@
+# make sure these values are exactly as in Management portal for using authorisation
+radarConfig:
+  projectId: "radar"
+  userId: "sub-1"
+  sourceId: "03d28e5c-e005-46d4-a9b3-279c27fbbc83"
+  baseUrl: "http://localhost:8081"
+  oAuthClientId: "radar-iot"
+  oAuthClientSecret: "secret"
+  metaToken: "dlsLwIw0E1cP"
+  schemaRegistryUrl: "http://localhost:8083/"
+  kafkaUrl: "http://localhost:8090/radar-gateway/"
+
+redisProperties:
+  host: redis
+  port: 6379
+  timeOut: 2000
+  password:
+
+# If a converter is not specified for a particular consumer for a sensor,
+# then the data from the sensor will not be forwarded to that consumer for processing
+sensorConfigs:
+  - sensorName: "mock"
+    inputTopic: "data-stream/sensors/mock"
+    outputTopic: "mock"
+    converterClasses:
+      - consumerName: "rest_proxy"
+        converterClass: "org.radarbase.iot.converter.avro.coralenviro.CoralEnviroTemperatureConverter"
+      - consumerName: "influx_db"
+        converterClass: "org.radarbase.iot.converter.influxdb.coralenviro.CoralEnviroHumidityInfluxDbConverter"
+
+dataConsumerConfigs:
+  - consumerClass: "org.radarbase.iot.consumer.RestProxyDataConsumer"
+    maxCacheSize: "1000"
+    uploadIntervalSeconds: "10"
+    consumerName: "rest_proxy"
+  - consumerClass: "org.radarbase.iot.consumer.InfluxDbDataConsumer"
+    maxCacheSize: "1000"
+    uploadIntervalSeconds: "10"
+    consumerName: "influx_db"
+
+influxDbConfig:
+  url: "http://localhost:8086"
+  username: "root"
+  password: "root"
+  dbName: "radarIot"
+  retentionPolicyName: "radarIotRetentionPolicy"
+  # Should be at least 1h
+  retentionPolicyDuration: "1h"
+  retentionPolicyReplicationFactor: 1

--- a/pubsub/redis_publisher.py
+++ b/pubsub/redis_publisher.py
@@ -11,7 +11,7 @@ logger = logging.getLogger('root')
 
 class RedisPublisher(Publisher):
 
-    def __init__(self, connection: RedisConnection = RedisConnection(),
+    def __init__(self, connection: RedisConnection,
                  publisher_thread_pool: ThreadPoolExecutor = ThreadPoolExecutor(max_workers=4)):
         self.redis_client = redis.Redis(connection_pool=connection.get_connection_pool())
         super().__init__(connection, publisher_thread_pool)


### PR DESCRIPTION
Solved the issue #15. The error was because of dynamic import initialises default argument  ```RedisConnection``` which leads it to connect with ```localhost:6379``` and throw ConnectionError. 